### PR TITLE
Adding exclude instruction for LICENSE in build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,6 +36,10 @@ android {
             buildConfigField 'String', 'LOG_LEVEL', LOG_ERROR
         }
     }
+
+    packagingOptions {
+        exclude 'META-INF/LICENSE'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
 in order to prevent jackson LICENSE conflicts when generating APK
